### PR TITLE
hotfix: Fix build rosetta-ingest step due to incorrect branch name

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -125,4 +125,4 @@ steps:
           variableDefined: "${{TAG_REPO}} == false"
           skipNextBuild: "${{SKIP_NEXT_BUILD}} == false"
     commands:
-      - codefresh run REGnosys/rosetta-ingest/rosetta-ingest --branch master --detach
+      - codefresh run REGnosys/rosetta-ingest/rosetta-ingest --branch main --detach


### PR DESCRIPTION
# Summary

Update rosetta-ingest build step to look fro `main` branch instead of `master`