### PR TITLE
Demo: annotating hand edits to an importer-generated CSV namespace

### DIFF
--- a/rosetta-source/src/main/rosetta/unavista-csv-enum.rosetta
+++ b/rosetta-source/src/main/rosetta/unavista-csv-enum.rosetta
@@ -3,5 +3,5 @@ version "${project.version}"
 
 enum TradingCapacityEnum: <"Capacity in which the firm executed the transaction.">
     DEAL <"Dealing on own account.">
-    MTCH <"Matched principal.">
+    MTCH <"Matched principal, as defined in Article 4(1)(38) of MiFID II.">
     AOTC <"Any other capacity.">

--- a/rosetta-source/src/main/rosetta/unavista-csv-type.rosetta
+++ b/rosetta-source/src/main/rosetta/unavista-csv-type.rosetta
@@ -12,8 +12,8 @@ type UnavistaTransaction: <"A single Unavista transaction report row.">
         [label "Quantity"]
     price number (1..1)
         [label "Price"]
-    tradingDateTime zonedDateTime (1..1)
-        [label "Trading Date Time"]
+    tradingDateTime zonedDateTime (1..1) <"Date and time at which the transaction was executed.">
+        [label "Execution Timestamp"]
 
 typeAlias Max52Text: string(maxLength: 52)
 


### PR DESCRIPTION
**Illustration only — not intended to merge.** Raised to show what the *annotate, don't block* guard looks like on a real pull request, for the STORY-1911 CSV import design.

## Setup (on the base branch, not in this diff)

`demo.unavista.csv` is an example namespace of the kind `model-import` would generate from CSV samples. Its `rune-config.yml` entry carries an **origin marker** and is deliberately **not** read-only:

```yaml
namespaceConfig:
- namespace: demo.unavista.csv
  origin:
    modelImport: csv
```

A new workflow, `annotate-generated-namespaces.yml`, reports on pull requests that touch such namespaces. It never fails — refining a generated model by hand is the intended workflow, so a blocking check would put a bypass label on nearly every PR and the signal would decay into a ritual.

## What this PR changes

Two ordinary refinements a modeller would make after an import:

| File | Edit | Level |
|---|---|---|
| `unavista-csv-type.rosetta` | renames the `[label]` on `tradingDateTime` to match the source column, and documents it | **warning** |
| `unavista-csv-enum.rosetta` | expands the documentation on `MTCH` | notice |

The label change is raised to warning because the CSV column binding depends on labels — that is the class of edit that can silently break ingestion. Documentation changes stay at notice level, so the warning keeps its meaning.

## What to look at

- **Files changed** — annotations appear inline against the edited lines.
- **The workflow run summary** — a table of every generated namespace the PR touches.
- The check itself is **green**. Visibility, not enforcement; correctness is left to review and to an ingestion test pack.

Note: the model omits a `schema <name> CSV` declaration, since this repo is on DSL 10.2.0 which predates that construct.